### PR TITLE
Add product token authentication

### DIFF
--- a/.github/workflows/buildvalidation.yml
+++ b/.github/workflows/buildvalidation.yml
@@ -1,0 +1,37 @@
+name: Build validation
+on:
+  push:
+      branches:
+        - master
+        - develop
+        - feature/**
+        - release/**
+        - hotfix/**
+      tags:
+        - v*
+  pull_request:
+    branches: 
+      - master
+      - develop
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Clone source
+        uses: actions/checkout@v1
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1
+
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v1
+
+      - name: MSBuild Version
+        run: msbuild -version
+
+      - name: Restore packages
+        run: nuget restore dsmr-api.sln
+
+      - name: Build 
+        run: msbuild.exe dsmr-api.sln /nologo /nr:false /p:configuration="Debug"

--- a/SensateIoT.SmartEnergy.Dsmr.Api/App_Start/SwaggerConfig.cs
+++ b/SensateIoT.SmartEnergy.Dsmr.Api/App_Start/SwaggerConfig.cs
@@ -1,10 +1,5 @@
-using System;
-using System.Web;
 using System.Web.Http;
-using WebActivatorEx;
-using SensateIoT.SmartEnergy.Dsmr.Api;
 using Swashbuckle.Application;
-
 
 namespace SensateIoT.SmartEnergy.Dsmr.Api
 {
@@ -12,7 +7,7 @@ namespace SensateIoT.SmartEnergy.Dsmr.Api
     {
         public static void Register()
         {
-            GlobalConfiguration.Configuration.EnableSwagger(c =>
+            GlobalConfiguration.Configuration.EnableSwagger("dsmr-docs/{apiVersion}/swagger", c =>
                     {
 						// If schemes are not explicitly provided in a Swagger 2.0 document, then the scheme used to access
 						// the docs is taken as the default. If your API supports multiple schemes and you want to be explicit
@@ -169,7 +164,7 @@ namespace SensateIoT.SmartEnergy.Dsmr.Api
                         //
                         //c.CustomProvider((defaultProvider) => new CachingSwaggerProvider(defaultProvider));
                     })
-                .EnableSwaggerUi(c => {
+                .EnableSwaggerUi("dsmr-docs/{*assetPath}", c => {
                         // Use the "DocumentTitle" option to change the Document title.
                         // Very helpful when you have multiple Swagger pages open, to tell them apart.
                         //

--- a/SensateIoT.SmartEnergy.Dsmr.Api/Controllers/DataController.cs
+++ b/SensateIoT.SmartEnergy.Dsmr.Api/Controllers/DataController.cs
@@ -12,7 +12,7 @@ using SensateIoT.SmartEnergy.Dsmr.DataAccess.Abstract;
 namespace SensateIoT.SmartEnergy.Dsmr.Api.Controllers
 {
 	[RoutePrefix("dsmr/v1/data")]
-	public class DataController : ApiController
+	public class DataController : BaseController 
 	{
 	    private readonly IOlapRepository m_olap;
 
@@ -26,6 +26,7 @@ namespace SensateIoT.SmartEnergy.Dsmr.Api.Controllers
 	    [Route("{sensorId}")]
 	    public async Task<IHttpActionResult> GetPowerAggregatesAsync(int sensorId, DateTime? start = null, DateTime? end = null)
 	    {
+			this.ThrowIfDeviceUnauthorized(sensorId);
 		    var now = DateTime.UtcNow;
 
 		    if(start == null) {

--- a/SensateIoT.SmartEnergy.Dsmr.Api/Middleware/AuthenticationMiddleware.cs
+++ b/SensateIoT.SmartEnergy.Dsmr.Api/Middleware/AuthenticationMiddleware.cs
@@ -29,7 +29,7 @@ namespace SensateIoT.SmartEnergy.Dsmr.Api.Middleware
 		{
 			logger.Info("Verifying product token.");
 
-			if(request.RequestUri.PathAndQuery.Contains("swagger")) {
+			if(request.RequestUri.PathAndQuery.Contains("dsmr-docs")) {
 				return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 			}
 

--- a/SensateIoT.SmartEnergy.Dsmr.Api/Middleware/AuthenticationMiddleware.cs
+++ b/SensateIoT.SmartEnergy.Dsmr.Api/Middleware/AuthenticationMiddleware.cs
@@ -69,9 +69,10 @@ namespace SensateIoT.SmartEnergy.Dsmr.Api.Middleware
 				return false;
 			}
 
-			var pt = await this.m_repo.GetProductTokenAsync(uuid, ct).ConfigureAwait(false);
+			var pt = await this.m_repo.GetProductTokenAsync(uuid, ct)
+				.ConfigureAwait(false);
 
-			if(uuid != pt.Token) {
+			if(uuid != pt?.Token) {
 				return false;
 			}
 

--- a/dsmr-api.sln
+++ b/dsmr-api.sln
@@ -22,6 +22,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		SECURITY.md = SECURITY.md
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Pipelines", "Pipelines", "{23B98C4A-0486-4CFA-9E5A-7B17CD52718C}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\buildvalidation.yml = .github\workflows\buildvalidation.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
This PR implements two improvements:

- Swagger documentation URL prefix (`dsmr-docs`). This makes it easier to navigate in production;
- Product token authentication in all API route handlers.