### PR TITLE
Improve energy computations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 06-06-2021
+### Added
+- Energy usage endpoint
+
+### Updated
+- Energy usage computation
+- Swagger documentation
+
 ## [1.4.2] - 30-05-2021
 ### Updated
 - Logout route method name

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,6 +10,7 @@ be answered, and issues/bug reports will be instantly closed.
 
 | Version   | Supported          |
 | --------- | ------------------ |
+| 1.5.x     | :white_check_mark: |
 | 1.4.x     | :white_check_mark: |
 | < 1.3.x   | :x:                |
 

--- a/SensateIoT.SmartEnergy.Dsmr.Api/Adapters/TwilioAdapter.cs
+++ b/SensateIoT.SmartEnergy.Dsmr.Api/Adapters/TwilioAdapter.cs
@@ -19,7 +19,9 @@ namespace SensateIoT.SmartEnergy.Dsmr.Api.Adapters
 
 		public TwilioAdapter(AppSettings settings)
 		{
-			this.m_resouce = IncomingPhoneNumberResource.Fetch(settings.TwilioPhoneSid);
+			if(settings.OtpEnabled) {
+				this.m_resouce = IncomingPhoneNumberResource.Fetch(settings.TwilioPhoneSid);
+			}
 		}
 
 		public static void Init(string account, string auth)

--- a/SensateIoT.SmartEnergy.Dsmr.Api/Controllers/AggregatesController.cs
+++ b/SensateIoT.SmartEnergy.Dsmr.Api/Controllers/AggregatesController.cs
@@ -14,6 +14,7 @@ using SensateIoT.SmartEnergy.Dsmr.Api.Exceptions;
 using SensateIoT.SmartEnergy.Dsmr.Data.DTO;
 using SensateIoT.SmartEnergy.Dsmr.Data.Models;
 using SensateIoT.SmartEnergy.Dsmr.DataAccess.Abstract;
+
 using DataPoint = SensateIoT.SmartEnergy.Dsmr.Data.DTO.DataPoint;
 using EnergyDataPoint = SensateIoT.SmartEnergy.Dsmr.Data.DTO.EnergyDataPoint;
 using EnvironmentDataPoint = SensateIoT.SmartEnergy.Dsmr.Data.DTO.EnvironmentDataPoint;

--- a/SensateIoT.SmartEnergy.Dsmr.Api/Properties/AssemblyInfo.cs
+++ b/SensateIoT.SmartEnergy.Dsmr.Api/Properties/AssemblyInfo.cs
@@ -38,5 +38,5 @@ using SensateIoT.SmartEnergy.Dsmr.Api;
 //
 // You can specify all the values or you can default the Revision and Build Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.4.2.0")]
-[assembly: AssemblyFileVersion("1.4.2.0")]
+[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.5.0.0")]

--- a/SensateIoT.SmartEnergy.Dsmr.Api/Web.config
+++ b/SensateIoT.SmartEnergy.Dsmr.Api/Web.config
@@ -13,7 +13,7 @@
 		<add key="webpages:Enabled" value="false" />
 		<add key="ClientValidationEnabled" value="true" />
 		<add key="UnobtrusiveJavaScriptEnabled" value="true" />
-    <add key="xmlCommentsPath" value="C:\Users\miche\Documents\Workspace\Sensate\smart-meter\dsmr-api\SensateIoT.SmartEnergy.Dsmr.Api\bin\dsmr-docs.xml" />
+    <add key="xmlCommentsPath" value="dsmr-docs.xml" />
     <add key="otpEnabled" value="false" />
     <add key="twilioAuthToken" value="" />
     <add key="twilioAccountToken" value="" />

--- a/SensateIoT.SmartEnergy.Dsmr.Api/Web.config
+++ b/SensateIoT.SmartEnergy.Dsmr.Api/Web.config
@@ -14,7 +14,7 @@
 		<add key="ClientValidationEnabled" value="true" />
 		<add key="UnobtrusiveJavaScriptEnabled" value="true" />
     <add key="xmlCommentsPath" value="C:\Users\miche\Documents\Workspace\Sensate\smart-meter\dsmr-api\SensateIoT.SmartEnergy.Dsmr.Api\bin\dsmr-docs.xml" />
-    <add key="otpEnabled" value="true" />
+    <add key="otpEnabled" value="false" />
     <add key="twilioAuthToken" value="" />
     <add key="twilioAccountToken" value="" />
     <add key="twilioPhoneToken" value="" />

--- a/SensateIoT.SmartEnergy.Dsmr.Data/Models/EnergyUsageData.cs
+++ b/SensateIoT.SmartEnergy.Dsmr.Data/Models/EnergyUsageData.cs
@@ -1,9 +1,14 @@
-﻿namespace SensateIoT.SmartEnergy.Dsmr.Data.Models
+﻿using Newtonsoft.Json;
+
+namespace SensateIoT.SmartEnergy.Dsmr.Data.Models
 {
 	public class EnergyUsageData
 	{
+		[JsonProperty("energyUsage")]
 		public decimal EnergyUsage { get; set; }
+		[JsonProperty("energyProduction")]
 		public decimal EnergyProduction { get; set; }
+		[JsonProperty("gasUsage")]
 		public decimal? GasUsage { get; set; }
 	}
 }

--- a/SensateIoT.SmartEnergy.Dsmr.Data/Models/EnergyUsageData.cs
+++ b/SensateIoT.SmartEnergy.Dsmr.Data/Models/EnergyUsageData.cs
@@ -1,0 +1,9 @@
+﻿namespace SensateIoT.SmartEnergy.Dsmr.Data.Models
+{
+	public class EnergyUsageData
+	{
+		public decimal EnergyUsage { get; set; }
+		public decimal EnergyProduction { get; set; }
+		public decimal? GasUsage { get; set; }
+	}
+}

--- a/SensateIoT.SmartEnergy.Dsmr.Data/SensateIoT.SmartEnergy.Dsmr.Data.csproj
+++ b/SensateIoT.SmartEnergy.Dsmr.Data/SensateIoT.SmartEnergy.Dsmr.Data.csproj
@@ -53,6 +53,7 @@
     <Compile Include="DTO\LoginResult.cs" />
     <Compile Include="DTO\User.cs" />
     <Compile Include="Models\Device.cs" />
+    <Compile Include="Models\EnergyUsageData.cs" />
     <Compile Include="Models\GroupedPowerData.cs" />
     <Compile Include="Models\OtpToken.cs" />
     <Compile Include="Models\ProductToken.cs" />

--- a/SensateIoT.SmartEnergy.Dsmr.DataAccess/Abstract/IOlapRepository.cs
+++ b/SensateIoT.SmartEnergy.Dsmr.DataAccess/Abstract/IOlapRepository.cs
@@ -3,7 +3,13 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-using SensateIoT.SmartEnergy.Dsmr.Data.DTO;
+using SensateIoT.SmartEnergy.Dsmr.Data.Models;
+
+using DataPoint = SensateIoT.SmartEnergy.Dsmr.Data.DTO.DataPoint;
+using EnergyDataPoint = SensateIoT.SmartEnergy.Dsmr.Data.DTO.EnergyDataPoint;
+using EnvironmentDataPoint = SensateIoT.SmartEnergy.Dsmr.Data.DTO.EnvironmentDataPoint;
+using GroupedPowerData = SensateIoT.SmartEnergy.Dsmr.Data.DTO.GroupedPowerData;
+using WeeklyHigh = SensateIoT.SmartEnergy.Dsmr.Data.DTO.WeeklyHigh;
 
 namespace SensateIoT.SmartEnergy.Dsmr.DataAccess.Abstract
 {
@@ -13,6 +19,7 @@ namespace SensateIoT.SmartEnergy.Dsmr.DataAccess.Abstract
 		Task<IEnumerable<EnergyDataPoint>> LookupPowerDataPerDayAsync(int sensorId, DateTime start, DateTime end, CancellationToken ct);
 		Task<IEnumerable<EnvironmentDataPoint>> LookupEnvironmentDataPerHourAsync(int sensorId, DateTime start, DateTime end, CancellationToken ct);
 		Task<IEnumerable<EnvironmentDataPoint>> LookupEnvironmentDataPerDayAsync(int sensorId, DateTime start, DateTime end, CancellationToken ct);
+		Task<EnergyUsageData> LookupEnergyDataAsync(int sensorId, DateTime start, DateTime end, CancellationToken ct);
 		Task<IEnumerable<GroupedPowerData>> LookupPowerDataByHour(int sensorId, DateTime start, DateTime end, CancellationToken ct);
 		Task<DataPoint> LookupLastDataPointAsync(int sensorId, CancellationToken ct);
 		Task<WeeklyHigh> LookupWeeklyHighAsync(int sensorId, CancellationToken ct);

--- a/SensateIoT.SmartEnergy.Dsmr.DataAccess/Repositories/OlapRepository.cs
+++ b/SensateIoT.SmartEnergy.Dsmr.DataAccess/Repositories/OlapRepository.cs
@@ -28,6 +28,7 @@ namespace SensateIoT.SmartEnergy.Dsmr.DataAccess.Repositories
 		private const string DsmrApi_SelectWeeklyHigh = "DsmrApi_SelectWeeklyHigh";
 		private const string DsmrApi_SelectDataPoints = "DsmrApi_SelectDataPoints";
 		private const string DsmrApi_SelectPowerDataByHour = "DsmrApi_SelectPowerDataByHour";
+		private const string DsmrApi_SelectEnergyDataBetween = "DsmrApi_SelectEnergyDataBetween";
 
 		private const string DsmrApi_SelectPowerDailyAverages = "DsmrApi_SelectPowerDailyAverages";
 		private const string DsmrApi_SelectEnvironmentDailyAverages = "DsmrApi_SelectEnvironmentDailyAverages";
@@ -100,6 +101,15 @@ namespace SensateIoT.SmartEnergy.Dsmr.DataAccess.Repositories
 				Pressure = x.Pressure,
 				RH = x.RH
 			});
+		}
+
+		public async Task<EnergyUsageData> LookupEnergyDataAsync(int sensorId, DateTime start, DateTime end, CancellationToken ct)
+		{
+			return await this.QuerySingleAsync<EnergyUsageData>(DsmrApi_SelectEnergyDataBetween,
+				ct,
+				"@sensorId", sensorId,
+				"@start", start,
+				"@end", end).ConfigureAwait(false);
 		}
 
 		public async Task<IEnumerable<GroupedPowerData>> LookupPowerDataByHour(int sensorId, DateTime start, DateTime end, CancellationToken ct)


### PR DESCRIPTION
Change the way energy usage and production (including gas) are computed. Instead of aggregating power usage, the
usage of energy is computed by differencing the actual meter readings.